### PR TITLE
Captures mouse to fix drag bug

### DIFF
--- a/COMPILE.txt
+++ b/COMPILE.txt
@@ -12,6 +12,7 @@
 // @code_url https://raw.github.com/egraether/mine3D/master/lib/Stats.js
 // @code_url https://raw.github.com/egraether/mine3D/master/lib/System.js
 // @code_url https://raw.github.com/egraether/mine3D/master/lib/jquery-1.7.1.js
+// @code_url https://raw.github.com/egraether/mine3D/master/lib/setCapture-polyfill.js
 
 // @code_url https://raw.github.com/egraether/mine3D/master/src/utilities.js
 // @code_url https://raw.github.com/egraether/mine3D/master/src/WebGLUtilities.js

--- a/index.html
+++ b/index.html
@@ -652,6 +652,7 @@
 <script type="text/javascript" charset="utf-8" src="lib/Stats.js"></script>
 <script type="text/javascript" charset="utf-8" src="lib/System.js"></script>
 <script type="text/javascript" charset="utf-8" src="lib/jquery-1.7.1.js"></script>
+<script type="text/javascript" charset="utf-8" src="lib/setCapture-polyfill.js"></script>
 
 <script type="text/javascript" charset="utf-8" src="src/utilities.js"></script>
 <script type="text/javascript" charset="utf-8" src="src/WebGLUtilities.js"></script>

--- a/lib/setCapture-polyfill.js
+++ b/lib/setCapture-polyfill.js
@@ -1,0 +1,66 @@
+/* Copyright 2016 Joseph N. Musser II, MIT license */
+
+if (typeof Element.prototype.setCapture === 'undefined') {
+    var mouseEventNames = ['click', 'dblclick', 'mousedown', 'mouseenter', 'mouseleave', 'mousemove', 'mouseout', 'mouseover', 'mouseup'];
+    var captureElement = null;
+
+    Element.prototype.setCapture = function () {
+        captureElement = this;
+        for (var i = 0; i < mouseEventNames.length; i++)
+            window.addEventListener(mouseEventNames[i], handleCapturedEvent, true);
+    };
+
+    var originalReleaseCapture = Document.prototype.releaseCapture;
+    Document.prototype.releaseCapture = function () {
+        if (originalReleaseCapture != null) originalReleaseCapture.call(this);
+
+        for (var i = 0; i < mouseEventNames.length; i++)
+            window.removeEventListener(mouseEventNames[i], handleCapturedEvent, true);
+        captureElement = null;
+    };
+
+    function handleCapturedEvent(event) {
+        try {
+            window.removeEventListener(event.type, handleCapturedEvent, true);
+            try {
+                captureElement.dispatchEvent(cloneMouseEvent(event));
+            } finally {
+                window.addEventListener(event.type, handleCapturedEvent, true);
+            }
+        } finally {
+            event.stopImmediatePropagation();
+        }
+    }
+
+    // Not intended to be used with subclasses of MouseEvent
+    function cloneMouseEvent(event) {
+        var eventToDispatch;
+
+        if (document.createEvent) { // IE prevents the use of new MouseEvent(ev.type, ev)
+            eventToDispatch = document.createEvent('MouseEvent');
+            eventToDispatch.initMouseEvent(event.type,
+                event.bubbles,
+                event.cancelable,
+                event.view,
+                event.detail,
+                event.screenX,
+                event.screenY,
+                event.clientX,
+                event.clientY,
+                event.ctrlKey,
+                event.altKey,
+                event.shiftKey,
+                event.metaKey,
+                event.button,
+                event.relatedTarget);
+        } else {
+            eventToDispatch = new MouseEvent(event.type, event);
+        }
+
+        var buttonsValue = event.buttons;
+        if (eventToDispatch.buttons !== buttonsValue)
+            Object.defineProperty(eventToDispatch, 'buttons', { get: function () { return buttonsValue; } });
+
+        return eventToDispatch;
+    }
+}

--- a/src/EventHandler.js
+++ b/src/EventHandler.js
@@ -48,7 +48,8 @@ var EventHandler = {
 	onMouseDown : function( event ) {
 
 		event.stopPropagation();
-
+		canvas.setCapture();
+		
 		this.state = "down";
 		this.button = event.button;
 
@@ -77,6 +78,7 @@ var EventHandler = {
 	onMouseUp : function( event ) {
 
 		event.stopPropagation();
+		document.releaseCapture();
 
 		if ( this.state === "down" ) {
 


### PR DESCRIPTION
When you are rotating the cube by dragging the mouse, it's not unusual for the mouse to pass over menu elements or even outside the window. Then the cube stops rotating and skips if you reenter. Even worse, if you accidentally let go of the button outside the canvas, the next time you bring the mouse back in the cube starts rotating as though the button was being held. Clicking puts an end to the rotating, but if you aren't careful where the rotating cubes end up, it can also put an end to the game and not typically a pleasant one. :wink: It can be rather frustrating to have to avoid all this when you just want to see the other side of the cube.

I happen to have solved a similar issue in a project of mine, so the fix was easy. On mousedown you have the containing element capture the mouse so that element receives all events no matter where the mouse goes. On mouseup, you release the capture and mouse events go to their normal sources. A polyfill is needed for consistent behavior in all the browsers.

I'm happy for this to be reviewed, and I'm also eager to for this to be deployed so I can use it. Thanks!