### PR TITLE
Fix typo in sweephard ID so high score shows on the scoreboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
 					<td>sweep</td>
 					<td id="sweepeasy"> - </td>
 					<td id="sweepmedium"> - </td>
-                    <td id="sweepehard"> - </td>
+                    <td id="sweephard"> - </td>
 				</tr>
 			</table>
 <br/>


### PR DESCRIPTION
The key used to store the high score for hard difficulty Sweep is misspelled in index.html. This causes the score to not display for this mode.